### PR TITLE
add_silencerによって、/app/以下だけを許可する

### DIFF
--- a/lib/active_record/dowsing/util.rb
+++ b/lib/active_record/dowsing/util.rb
@@ -18,8 +18,7 @@ module ActiveRecord
           cleaner.add_filter   { |line| line.remove(Rails.root.to_s) }
           cleaner.add_filter   { |line| line.remove('*') } # Sanitize comment
 
-          cleaner.add_silencer { |line| line =~ %r{activerecord-dowsing/lib} }
-          cleaner.add_silencer { |line| line =~ /gems/ }
+          cleaner.add_silencer { |line| !line.start_with?('/app/') }
         end
 
         @cleaner.clean(stack)


### PR DESCRIPTION
```
/* /usr/local/rbenv/versions/2.4.3/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'#hoge */
```
のようなコメントが埋め込まれるのを防ぎたい。

ただし既存のテストはコケる。